### PR TITLE
CA-246770: check if rtnl_addr_alloc_cache has been successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.02 PACKAGE=mirage-block-volume 
+  - OCAML_VERSION=4.02 PACKAGE=ocaml-netlink
 

--- a/lib/netlink.ml
+++ b/lib/netlink.ml
@@ -120,6 +120,8 @@ module Link = struct
 
 	type stat_id = RX_PACKETS | TX_PACKETS | RX_BYTES | TX_BYTES | RX_ERRORS | TX_ERRORS
 
+	exception AllocCacheError
+
 	let int_of_stat_id = function
 		| RX_PACKETS -> 0
 		| TX_PACKETS -> 1
@@ -146,8 +148,8 @@ module Link = struct
 
 	let cache_alloc s =
 		let cache = allocate Cache.t null in
-		let _ = alloc_cache' s 0 cache in
-		cache
+		let ret = alloc_cache' s 0 cache in
+		if ret = 0 then cache else raise AllocCacheError
 
 	let cache_iter f cache =
 		Cache.iter f cache t

--- a/opam
+++ b/opam
@@ -1,9 +1,9 @@
-opam-version: "1"
+opam-version: "1.2"
+authors: "rob.hoes@citrix.com"
 maintainer: "rob.hoes@citrix.com"
-build: [
-  [make]
-  [make "install"]
-]
+homepage: "https://github.com/xapi-project/ocaml-netlink"
+build: [make]
+install: [make "install"]
 remove: [
   [make "uninstall"]
   ["ocamlfind" "remove" "netlink"]
@@ -13,8 +13,7 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-os: [ "linux" ]
 depexts: [
  [ ["debian"] ["libnl-3" ] ]
- [ ["ubuntu"] ["libnl-3-200" ] ]
+ [ ["ubuntu"] ["libnl-3-200" "libnl-route-3-200"] ]
 ]


### PR DESCRIPTION
This change by itself should prevent the segmentation fault in `xcp-networkd` when `rtnl_addr_alloc_cache` is unable to fill the cache. As it is now, this will be caught by the error control in the network monitor and give a decent error message.

A patch to `xcp-networkd` to test different possible additional mitigations is under test but does not prevent this change to be already merged.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>